### PR TITLE
Updates for pyLDAPI supporting ConnegP

### DIFF
--- a/model/sample.py
+++ b/model/sample.py
@@ -361,7 +361,7 @@ class SampleRenderer(Renderer):
             render_template(
                 self.alternates_template or 'alternates.html',
                 register_name='Sample Register',
-                class_uri=self.uri,
+                class_uri=config.URI_SAMPLE_CLASS,
                 instance_uri=config.URI_SAMPLE_INSTANCE_BASE + self.igsn,
                 default_view_token=self.default_view_token,
                 views=self.views

--- a/model/sample.py
+++ b/model/sample.py
@@ -49,7 +49,7 @@ class SampleRenderer(Renderer):
                 'An XML-only metadata schema for descriptive elements of IGSNs',
                 ['text/xml'],
                 'text/xml',
-                namespace='https://confluence.csiro.au/display/AusIGSN/CSIRO+IGSN+IMPLEMENTATION'
+                profile_uri='https://confluence.csiro.au/display/AusIGSN/CSIRO+IGSN+IMPLEMENTATION'
             ),
 
             'dct': View(
@@ -64,7 +64,7 @@ class SampleRenderer(Renderer):
                     "text/xml"
                 ],
                 'text/turtle',
-                namespace='http://purl.org/dc/terms/'
+                profile_uri='http://purl.org/dc/terms/'
             ),
 
             'igsn': View(
@@ -72,7 +72,7 @@ class SampleRenderer(Renderer):
                 'The official IGSN XML schema',
                 ['text/xml'],
                 'text/xml',
-                namespace='http://schema.igsn.org/description/'
+                profile_uri='http://schema.igsn.org/description/'
             ),
 
             'igsn-r1': View(
@@ -80,7 +80,7 @@ class SampleRenderer(Renderer):
                 'Version 1 of the official IGSN XML schema',
                 ['text/xml'],
                 'text/xml',
-                namespace='http://schema.igsn.org/description/1.0'
+                profile_uri='http://schema.igsn.org/description/1.0'
             ),
 
             'igsn-o': View(
@@ -88,7 +88,7 @@ class SampleRenderer(Renderer):
                 "An OWL ontology of Samples based on CSIRO's XML-based IGSN schema",
                 ["text/html", "text/turtle", "application/rdf+xml", "application/rdf+json"],
                 'text/html',
-                namespace='http://pid.geoscience.gov.au/def/ont/ga/igsn'
+                profile_uri='http://pid.geoscience.gov.au/def/ont/ga/igsn'
             ),
 
             'prov': View(
@@ -96,7 +96,7 @@ class SampleRenderer(Renderer):
                 "The W3C's provenance data model, PROV",
                 ["text/html", "text/turtle", "application/rdf+xml", "application/rdf+json"],
                 "text/turtle",
-                namespace="http://www.w3.org/ns/prov/"
+                profile_uri="http://www.w3.org/ns/prov/"
             ),
 
             'sosa': View(
@@ -104,7 +104,7 @@ class SampleRenderer(Renderer):
                 "The W3C's Sensor, Observation, Sample, and Actuator ontology within the Semantic Sensor Networks ontology",
                 ["text/turtle", "application/rdf+xml", "application/rdf+json"],
                 "text/turtle",
-                namespace="http://www.w3.org/ns/sosa/"
+                profile_uri="http://www.w3.org/ns/sosa/"
             ),
         }
 
@@ -322,36 +322,39 @@ class SampleRenderer(Renderer):
             if self.format == 'text/html':
                 return self.export_html(model_view=self.view)
             else:
-                return Response(self.export_rdf(self.view, self.format), mimetype=self.format)
+                return Response(self.export_rdf(self.view, self.format), mimetype=self.format, headers=self.headers)
         elif self.view == 'dct':
             if self.format == 'text/html':
                 return self.export_html(model_view=self.view)
             elif self.format == 'text/xml':
-                return Response(self.export_dct_xml(), mimetype=self.format)
+                return Response(self.export_dct_xml(), mimetype=self.format, headers=self.headers)
             else:
-                return Response(self.export_rdf(self.view, self.format), mimetype=self.format)
+                return Response(self.export_rdf(self.view, self.format), mimetype=self.format, headers=self.headers)
         elif self.view == 'igsn':  # only XML for this view
             return Response(
                 '<?xml version="1.0" encoding="utf-8"?>\n' + self.export_igsn_xml(),
-                mimetype='text/xml'
+                mimetype='text/xml',
+                headers=self.headers
             )
         elif self.view == 'igsn-r1':  # only XML for this view
             return Response(
                 '<?xml version="1.0" encoding="utf-8"?>\n' + self.export_igsn_r1_xml(),
-                mimetype='text/xml'
+                mimetype='text/xml',
+                headers=self.headers
             )
         elif self.view == 'csirov3':  # only XML for this view
             return Response(
                 '<?xml version="1.0" encoding="utf-8"?>\n' + self.export_csirov3_xml(),
-                mimetype='text/xml'
+                mimetype='text/xml',
+                headers=self.headers
             )
         elif self.view == 'prov':
             if self.format == 'text/html':
                 return self.export_html(model_view=self.view)
             else:
-                return Response(self.export_rdf(self.view, self.format), mimetype=self.format)
+                return Response(self.export_rdf(self.view, self.format), mimetype=self.format, headers=self.headers)
         elif self.view == 'sosa':  # RDF only for this view
-            return Response(self.export_rdf(self.view, self.format), mimetype=self.format)
+            return Response(self.export_rdf(self.view, self.format), mimetype=self.format, headers=self.headers)
 
     def _render_alternates_view_html(self):
         return Response(
@@ -1118,9 +1121,7 @@ class SampleRenderer(Renderer):
 
         # add in the Pingback header links as they are valid for all HTML views
         pingback_uri = config.URI_SAMPLE_INSTANCE_BASE + self.igsn + "/pingback"
-        headers = {
-            'Link': '<{}>;rel = "http://www.w3.org/ns/prov#pingback"'.format(pingback_uri)
-        }
+        self.headers['Link'] += ', <{}>; rel="http://www.w3.org/ns/prov#pingback"'.format(pingback_uri)
 
         return Response(
             render_template(
@@ -1139,7 +1140,7 @@ class SampleRenderer(Renderer):
                 gmap_bbox=self._generate_sample_gmap_bbox(),
                 citation=self._make_citation()
             ),
-            headers=headers
+            headers=self.headers
         )
 
 

--- a/model/site.py
+++ b/model/site.py
@@ -256,7 +256,7 @@ class SiteRenderer(Renderer):
         return Response(
             render_template(
                 self.alternates_template or 'alternates.html',
-                instance_uri=self.uri,
+                instance_uri=config.URI_SITE_CLASS,
                 register_name='Site Register',
                 class_uri=self.site_type,
                 default_view_token=self.default_view_token,

--- a/model/site.py
+++ b/model/site.py
@@ -20,7 +20,7 @@ class SiteRenderer(Renderer):
                 "Geoscience Australia's Public Data Model ontology",
                 ["text/html", "text/turtle", "application/rdf+xml", "application/rdf+json"],
                 'text/html',
-                namespace='http://pid.geoscience.gov.au/def/ont/ga/pdm'
+                profile_uri='http://pid.geoscience.gov.au/def/ont/ga/pdm'
             ),
 
             "nemsr": View(
@@ -28,7 +28,7 @@ class SiteRenderer(Renderer):
                 "The National Environmental Monitoring Sites Register",
                 ["application/vnd.geo+json"],
                 "application/vnd.geo+json",
-                namespace="http://www.neii.gov.au/nemsr"
+                profile_uri="http://www.neii.gov.au/nemsr"
             )
         }
 
@@ -248,7 +248,7 @@ class SiteRenderer(Renderer):
             if self.format == 'text/html':
                 return self.export_html(model_view=self.view)
             else:
-                return Response(self.export_rdf(self.view, self.format), mimetype=self.format)
+                return Response(self.export_rdf(self.view, self.format), mimetype=self.format, headers=self.headers)
         elif self.view == 'nemsr':
             return self.export_nemsr_geojson()
 
@@ -330,7 +330,8 @@ class SiteRenderer(Renderer):
         }
         return Response(
             json.dumps(site),
-            mimetype='application/vnd.geo+json'
+            mimetype='application/vnd.geo+json',
+            headers=self.headers
         )
 
     def export_rdf(self, model_view='pdm', rdf_mime='text/turtle'):
@@ -426,9 +427,7 @@ class SiteRenderer(Renderer):
 
         # add in the Pingback header links as they are valid for all HTML views
         pingback_uri = config.URI_SITE_INSTANCE_BASE + self.site_no + "/pingback"
-        headers = {
-            'Link': '<{}>;rel = "http://www.w3.org/ns/prov#pingback"'.format(pingback_uri)
-        }
+        self.headers['Link'] += ', <{}>; rel="http://www.w3.org/ns/prov#pingback"'.format(pingback_uri)
 
         return Response(
             render_template(
@@ -447,7 +446,7 @@ class SiteRenderer(Renderer):
                 coords=self.coords,
                 base_url=config.BASE_URL
             ),
-            headers=headers
+            headers=self.headers
         )
 
 

--- a/model/site.py
+++ b/model/site.py
@@ -18,7 +18,7 @@ class SiteRenderer(Renderer):
             "pdm": View(
                 "GA's Public Data Model View",
                 "Geoscience Australia's Public Data Model ontology",
-                ["text/html", "text/turtle", "application/rdf+xml", "application/rdf+json"],
+                ["text/html", "text/turtle", "application/rdf+xml", "application/ld+json"],
                 'text/html',
                 profile_uri='http://pid.geoscience.gov.au/def/ont/ga/pdm'
             ),
@@ -242,15 +242,17 @@ class SiteRenderer(Renderer):
         if self.not_found:
             return Response('Sample {} not found.'.format(self.site_no), status=404, mimetype='text/plain')
 
-        if self.view == 'alternates':
-            return self._render_alternates_view()
-        elif self.view == 'pdm':
-            if self.format == 'text/html':
-                return self.export_html(model_view=self.view)
-            else:
-                return Response(self.export_rdf(self.view, self.format), mimetype=self.format, headers=self.headers)
-        elif self.view == 'nemsr':
-            return self.export_nemsr_geojson()
+        response = super().render()  # alternates and all view
+        if response is None:
+            if self.view == 'pdm':
+                if self.format == 'text/html':
+                    return self.export_html(model_view=self.view)
+                else:
+                    return Response(self.export_rdf(self.view, self.format), mimetype=self.format, headers=self.headers)
+            elif self.view == 'nemsr':
+                return self.export_nemsr_geojson()
+        else:
+            return response
 
     def _render_alternates_view_html(self):
         return Response(

--- a/model/survey.py
+++ b/model/survey.py
@@ -15,7 +15,7 @@ class SurveyRenderer(Renderer):
         and PROV-O, the Provenance Ontology.
     """
 
-    URI_MISSSING = 'http://www.opengis.net/def/nil/OGC/0/missing'
+    URI_MISSING = 'http://www.opengis.net/def/nil/OGC/0/missing'
     URI_INAPPLICABLE = 'http://www.opengis.net/def/nil/OGC/0/inapplicable'
     URI_GA = 'http://pid.geoscience.gov.au/org/ga'
 
@@ -26,7 +26,7 @@ class SurveyRenderer(Renderer):
                 "Geoscience Australia's Public Data Model",
                 ['text/html', 'text/turtle', 'application/rdf+xml', 'application/rdf+json', 'application/json'],
                 'text/html',
-                profile_uri=None
+                profile_uri='http://example.org/profile/gapd'
             ),
 
             "argus": View(
@@ -34,7 +34,7 @@ class SurveyRenderer(Renderer):
                 "Geoscience Australia's Airborne Reductions Group Utility System (ARGUS)",
                 ["text/xml"],
                 'text/xml',
-                profile_uri=None
+                profile_uri='http://example.org/profile/argus'
             ),
 
             'sosa': View(
@@ -134,8 +134,8 @@ class SurveyRenderer(Renderer):
             render_template(
                 self.alternates_template or 'alternates.html',
                 register_name='Survey Register',
-                class_uri=self.uri,
-                instance_uri=config.BASE_URI_SURVEY + self.survey_no,
+                class_uri=config.URI_SURVEY_CLASS,
+                instance_uri=config.URI_SURVEY_INSTANCE_BASE + self.survey_no,
                 default_view_token=self.default_view_token,
                 views=self.views
             ),

--- a/model/survey.py
+++ b/model/survey.py
@@ -26,7 +26,7 @@ class SurveyRenderer(Renderer):
                 "Geoscience Australia's Public Data Model",
                 ['text/html', 'text/turtle', 'application/rdf+xml', 'application/rdf+json', 'application/json'],
                 'text/html',
-                namespace=None
+                profile_uri=None
             ),
 
             "argus": View(
@@ -34,7 +34,7 @@ class SurveyRenderer(Renderer):
                 "Geoscience Australia's Airborne Reductions Group Utility System (ARGUS)",
                 ["text/xml"],
                 'text/xml',
-                namespace=None
+                profile_uri=None
             ),
 
             'sosa': View(
@@ -42,7 +42,7 @@ class SurveyRenderer(Renderer):
                 "The W3C's Sensor, Observation, Sample, and Actuator ontology within the Semantic Sensor Networks ontology",
                 ["text/turtle", "application/rdf+xml", "application/rdf+json"],
                 "text/turtle",
-                namespace="http://www.w3.org/ns/sosa/"
+                profile_uri="http://www.w3.org/ns/sosa/"
             ),
 
             'prov': View(
@@ -50,7 +50,7 @@ class SurveyRenderer(Renderer):
                 "The W3C's provenance data model, PROV",
                 ["text/html", "text/turtle", "application/rdf+xml", "application/rdf+json"],
                 "text/turtle",
-                namespace="http://www.w3.org/ns/prov/"
+                profile_uri="http://www.w3.org/ns/prov/"
             )
         }
 
@@ -118,16 +118,16 @@ class SurveyRenderer(Renderer):
             if self.format == 'text/html':
                 return self.export_html(model_view=self.view)
             else:
-                return Response(self.export_rdf(self.view, self.format), mimetype=self.format)
+                return Response(self.export_rdf(self.view, self.format), mimetype=self.format, headers=self.headers)
         elif self.view == 'argus':  # XML only for this controller
             return redirect(config.XML_API_URL_SURVEY.format(self.survey_no), code=303)
         elif self.view == 'prov':
             if self.format == 'text/html':
                 return self.export_html(model_view=self.view)
             else:
-                return Response(self.export_rdf(self.view, self.format), mimetype=self.format)
+                return Response(self.export_rdf(self.view, self.format), mimetype=self.format, headers=self.headers)
         elif self.view == 'sosa':  # RDF only for this controller
-            return Response(self.export_rdf(self.view, self.format), mimetype=self.format)
+            return Response(self.export_rdf(self.view, self.format), mimetype=self.format, headers=self.headers)
 
     def _render_alternates_view_html(self):
         return Response(

--- a/model/survey.py
+++ b/model/survey.py
@@ -24,7 +24,7 @@ class SurveyRenderer(Renderer):
             "gapd": View(
                 'GA Public Data View',
                 "Geoscience Australia's Public Data Model",
-                ['text/html', 'text/turtle', 'application/rdf+xml', 'application/rdf+json', 'application/json'],
+                ['text/html', 'text/turtle', 'application/rdf+xml', 'application/ld+json', 'application/json'],
                 'text/html',
                 profile_uri='http://example.org/profile/gapd'
             ),
@@ -40,7 +40,7 @@ class SurveyRenderer(Renderer):
             'sosa': View(
                 'SOSA View',
                 "The W3C's Sensor, Observation, Sample, and Actuator ontology within the Semantic Sensor Networks ontology",
-                ["text/turtle", "application/rdf+xml", "application/rdf+json"],
+                ["text/turtle", "application/rdf+xml", "application/ld+json"],
                 "text/turtle",
                 profile_uri="http://www.w3.org/ns/sosa/"
             ),
@@ -48,7 +48,7 @@ class SurveyRenderer(Renderer):
             'prov': View(
                 'PROV View',
                 "The W3C's provenance data model, PROV",
-                ["text/html", "text/turtle", "application/rdf+xml", "application/rdf+json"],
+                ["text/html", "text/turtle", "application/rdf+xml", "application/ld+json"],
                 "text/turtle",
                 profile_uri="http://www.w3.org/ns/prov/"
             )
@@ -112,22 +112,25 @@ class SurveyRenderer(Renderer):
     def render(self):
         if self.survey_name is None:
             return Response('Survey with ID {} not found.'.format(self.survey_no), status=404, mimetype='text/plain')
-        if self.view == "alternates":
-            return self._render_alternates_view()
-        elif self.view == 'gapd':
-            if self.format == 'text/html':
-                return self.export_html(model_view=self.view)
-            else:
+
+        response = super().render()  # alternates and all view
+        if response is None:
+            if self.view == 'gapd':
+                if self.format == 'text/html':
+                    return self.export_html(model_view=self.view)
+                else:
+                    return Response(self.export_rdf(self.view, self.format), mimetype=self.format, headers=self.headers)
+            elif self.view == 'argus':  # XML only for this controller
+                return redirect(config.XML_API_URL_SURVEY.format(self.survey_no), code=303)
+            elif self.view == 'prov':
+                if self.format == 'text/html':
+                    return self.export_html(model_view=self.view)
+                else:
+                    return Response(self.export_rdf(self.view, self.format), mimetype=self.format, headers=self.headers)
+            elif self.view == 'sosa':  # RDF only for this controller
                 return Response(self.export_rdf(self.view, self.format), mimetype=self.format, headers=self.headers)
-        elif self.view == 'argus':  # XML only for this controller
-            return redirect(config.XML_API_URL_SURVEY.format(self.survey_no), code=303)
-        elif self.view == 'prov':
-            if self.format == 'text/html':
-                return self.export_html(model_view=self.view)
-            else:
-                return Response(self.export_rdf(self.view, self.format), mimetype=self.format, headers=self.headers)
-        elif self.view == 'sosa':  # RDF only for this controller
-            return Response(self.export_rdf(self.view, self.format), mimetype=self.format, headers=self.headers)
+        else:
+            return response
 
     def _render_alternates_view_html(self):
         return Response(

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ flask-compress
 flask-paginate
 lxml
 rdflib
+rdflib-jsonld
 pyldapi
 pytest
 PyYAML

--- a/view/static/css/gsv_theme.css
+++ b/view/static/css/gsv_theme.css
@@ -87,7 +87,7 @@ td#quote {
 }
 
 #contact-us {
-    background: #006983 url("/samples/static/img/right-arrow.png") no-repeat 90% 50%;
+    background: #006983 url("/static/img/ga/right-arrow.png") no-repeat 90% 50%;
     padding: 7px;
     text-decoration:none;
 }

--- a/view/static/css/master_theme.css
+++ b/view/static/css/master_theme.css
@@ -122,7 +122,7 @@ td#quote {
 }
 
 #contact-us {
-    background: #006983 url("/samples/static/img/ga/right-arrow.png") no-repeat 90% 50%;
+    background: #006983 url("/static/img/ga/right-arrow.png") no-repeat 90% 50%;
     padding: 7px;
     text-decoration:none;
 }


### PR DESCRIPTION
Only 2 substantive changes: namespace parameter for View() constructor now renamed profile_uri and HTTP headers always carries through from renderer.py (in pyLDAPI) to derived renderer class (e.g. SampleRenderer). Also fixed missing View profile_uris for Surveys, link for img etc.